### PR TITLE
In 'Administration' => 'Modules' you can configure the module and go back w/o any error

### DIFF
--- a/controllers/AdminController.php
+++ b/controllers/AdminController.php
@@ -8,6 +8,7 @@
 
 namespace humhub\modules\autofollow\controllers;
 
+use humhub\modules\autofollow\models\ConfigureForm;
 use Yii;
 
 /**
@@ -20,14 +21,19 @@ class AdminController extends \humhub\modules\admin\components\Controller
 
     public function actionIndex()
     {
-        $model = new \humhub\modules\autofollow\models\ConfigureForm();
+        $model = new ConfigureForm();
         $model->loadSettings();
 
         if ($model->load(Yii::$app->request->post()) && $model->save()) {
             $this->view->saved();
         }
 
-        return $this->render('index', ['model' => $model]);
+        $prevPage = Yii::$app->request->referrer ?: Yii::$app->homeUrl;
+
+        return $this->render('index', [
+            'model' => $model,
+            'prevPage' => $prevPage
+        ]);
     }
 
 }

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -23,7 +23,7 @@ use humhub\modules\user\widgets\UserPickerField;
         </div>
         <div class="form-group">
             <?= Html::saveButton() ?>
-            <?= Html::a(Yii::t('base', 'Back'), '/admin/modules', ['class' => 'btn btn-default pull-right']); ?>
+            <?= Html::a(Yii::t('base', 'Back'), $prevPage, ['class' => 'btn btn-default pull-right']); ?>
         </div>
         <?php ActiveForm::end(); ?>
     </div>


### PR DESCRIPTION
if you are in 'Administration' => 'Modules' and you go to the auto-follow module, and then you want to go 'back' using the back button did not work until now