### PR TITLE
deprecated statements removed

### DIFF
--- a/config.php
+++ b/config.php
@@ -7,8 +7,7 @@ return [
     'class' => 'humhub\modules\autofollow\Module',
     'namespace' => 'humhub\modules\autofollow',
     'events' => [
-        
-        [User::className(), User::EVENT_AFTER_INSERT, ['humhub\modules\autofollow\Events', 'onAfterUserCreate']],        
+
+        [User::class, User::EVENT_AFTER_INSERT, ['humhub\modules\autofollow\Events', 'onAfterUserCreate']],
     ]
 ];
-?>

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -17,8 +17,8 @@ use humhub\modules\user\widgets\UserPickerField;
 
         <?php $form = ActiveForm::begin(); ?>
         <div class="form-group">
-            <?= $form->field($model, 'spaces')->widget(SpacePickerField::className())->label(false); ?>
-            <?= $form->field($model, 'users')->widget(UserPickerField::className(), ['placeholderMore' => Yii::t('AutoFollowModule.setting', 'Add User')])->label(false); ?>
+            <?= $form->field($model, 'spaces')->widget(SpacePickerField::class)->label(false); ?>
+            <?= $form->field($model, 'users')->widget(UserPickerField::class, ['placeholderMore' => Yii::t('AutoFollowModule.setting', 'Add User')])->label(false); ?>
             <?= $form->field($model, 'assignAll')->checkbox(); ?>
         </div>
         <div class="form-group">


### PR DESCRIPTION
fix: old way of gettings class name '::className()' is replaced with '::class'